### PR TITLE
Remove --depth from clone command

### DIFF
--- a/build-k1-xgcc.sh
+++ b/build-k1-xgcc.sh
@@ -28,7 +28,7 @@ function git_clone() {
 	git fetch
 	cd -
     else
-	git clone --depth 1 -b coolidge ${repo}
+	git clone -b coolidge ${repo}
     fi
 
     if [[ ! -z "${sha1}" ]]


### PR DESCRIPTION
It was not possible to build anything but the branch TIP.