### PR TITLE
Rename k1 to kvx, use binutils instead of gdb

### DIFF
--- a/.github/workflows/build-kvx-elf.yml
+++ b/.github/workflows/build-kvx-elf.yml
@@ -21,4 +21,4 @@ jobs:
     - name: Install deps
       run: ./install-ubuntu-prereq.sh
     - name: Build
-      run: source last.refs && ./build-k1-xgcc.sh test-build
+      run: source last.refs && ./build-kvx-xgcc.sh test-build

--- a/.github/workflows/release-kvx-elf.yml
+++ b/.github/workflows/release-kvx-elf.yml
@@ -21,7 +21,7 @@ jobs:
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
     - name: Build
-      run: source last.refs && ./build-k1-xgcc.sh gcc-kalray-kvx-${{ steps.get_version.outputs.VERSION }}
+      run: source last.refs && ./build-kvx-xgcc.sh gcc-kalray-kvx-${{ steps.get_version.outputs.VERSION }}
     - name: Package
       if: matrix.os == 'ubuntu-latest'
       run: tar -cvzf gcc-kalray-kvx-${{ steps.get_version.outputs.VERSION }}.tar.gz gcc-kalray-kvx-${{ steps.get_version.outputs.VERSION }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To build elf toolchain for this version:
 
 ```bash
 source ./last.refs
-./build-scripts/build-k1-xgcc.sh <prefix>
+./build-scripts/build-kvx-xgcc.sh <prefix>
 ```
 Prefix is the path where toolchain will be installed.
 
@@ -71,13 +71,13 @@ index 5a728e8..bc919fa 100755
 
 https://github.com/kalray/gcc
 
-To make OS specific toolchain, it is possible to modify gcc driver to get k1-<os>-gcc. This driver will be able to link specific OS librairies for example.
+To make OS specific toolchain, it is possible to modify gcc driver to get kvx-<os>-gcc. This driver will be able to link specific OS librairies for example.
 First of all, GCC internal documentation can be found here: https://gcc.gnu.org/onlinedocs/gccint
 
-K1 is the Kalray's processor name. Main k1 specific targetting files are here:
+KVX is the Kalray's processor familly name. Main KVX specific targetting files are here:
 
 ```
-gcc/config/k1/
+gcc/config/kvx/
 ```
 It targets several toolchain versions:
 - elf
@@ -86,17 +86,17 @@ It targets several toolchain versions:
 - linux
 
 Files that configure gcc's driver for elf toolchain:
-- k1-elf.h
-- k1.opt
+- kvx-elf.h
+- kvx.opt
 - t-elf
-- t-k1
+- t-kvx
 
 These files are used in gcc/config.gcc:
 
 ```bash
-k1-*-elf*)
-	tm_file="${tm_file} elfos.h dbxelf.h k1/k1-elf.h newlib-stdint.h"
-	tmake_file="k1/t-k1 k1/t-elf"
+kvx-*-elf*)
+	tm_file="${tm_file} elfos.h dbxelf.h kvx/kvx-elf.h newlib-stdint.h"
+	tmake_file="kvx/t-kvx kvx/t-elf"
 	;;
 ```
 
@@ -118,11 +118,11 @@ index 7fabc3d..70595a5 100755
                 ;;
         -qnx*)
 ```
-- create k1-freertos.h from k1-elf.h. For FreeRTOS:
+- create kvx-freertos.h from kvx-elf.h. For FreeRTOS:
 ```c
-cat gcc/config/k1/k1-freertos.h
-/* Machine description for K1 MPPA architecture.
-   Copyright (C) 2018 Kalray Inc.
+cat gcc/config/kvx/kvx-freertos.h
+/* Machine description for KVX MPPA architecture familly.
+   Copyright (C) 2020 Kalray Inc.
 
    This file is part of GCC.
 
@@ -140,8 +140,8 @@ cat gcc/config/k1/k1-freertos.h
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
 
-#ifndef GCC_K1_MPPA_FREERTOS
-#define GCC_K1_MPPA_FREERTOS
+#ifndef GCC_KVX_MPPA_FREERTOS
+#define GCC_KVX_MPPA_FREERTOS
 
 #define STARTFILE_SPEC " crti%O%s crtbegin%O%s crt0%O%s"
 #define ENDFILE_SPEC " crtend%O%s crtn%O%s"
@@ -161,26 +161,26 @@ cat gcc/config/k1/k1-freertos.h
 #define LINK_SPEC \
   LINK_SPEC_COMMON
 
-#endif /* GCC_K1_MPPA_FREERTOS */
+#endif /* GCC_KVX_MPPA_FREERTOS */
 ```
 
 - create t-freertos from t-elf. Example for FreeRTOS:
 ```
-cat ./gcc/config/k1/t-freertos
+cat ./gcc/config/kvx/t-freertos
 MULTILIB_OPTIONS = fno-exceptions
 MULTILIB_DIRNAMES = noexceptions
 ```
 - add configuration line in gcc/config.gcc for freeRTOS:
 ```bash
-k1-*-freertos*)
-	tm_file="${tm_file} elfos.h dbxelf.h k1/k1-freertos.h newlib-stdint.h"
-	tmake_file="k1/t-k1 k1/t-freertos"
+kvx-*-freertos*)
+	tm_file="${tm_file} elfos.h dbxelf.h kvx/kvx-freertos.h newlib-stdint.h"
+	tmake_file="kvx/t-kvx kvx/t-freertos"
 	;;
 ```
 
 ### Newlib (libc)
 
-Equivalent to board support package of Newlib is in newlib/libgloss/k1-elf for Elf toolchain.
+Equivalent to board support package of Newlib is in newlib/libgloss/kvx-elf for Elf toolchain.
 It contains support for:
 - boot: start.S, boot_c.c, boot_args.c, crt0.c, crti.c and crtn.c
 - bsp: bsp.c, exceptions.c exceptions_pl0.c, handlers.c, syscall.c, context.c and diagnostic.c
@@ -205,8 +205,8 @@ index 7c526fb..54ab48d 100755
         -qnx*)
 ```
 - FreeRTOS libgloss:
- - copy all libgloss/k1-elf directory to libgloss/k1-freertos
- - Defines k1-freertos in libgloss/configure.in:
+ - copy all libgloss/kvx-elf directory to libgloss/kvx-freertos
+ - Defines kvx-freertos in libgloss/configure.in:
 
 ```diff
 git diff ./configure.in
@@ -215,11 +215,11 @@ index 61eda97..13df055 100644
 --- a/libgloss/configure.in
 +++ b/libgloss/configure.in
 @@ -126,6 +126,10 @@ case "${target}" in
-        AC_CONFIG_SUBDIRS([k1-cos])
+        AC_CONFIG_SUBDIRS([kvx-cos])
         config_libnosys=false
         ;;
-+  k1*-*-freertos)
-+       AC_CONFIG_SUBDIRS([k1-freertos])
++  kvx*-*-freertos)
++       AC_CONFIG_SUBDIRS([kvx-freertos])
 +       config_libnosys=false
 +       ;;
    lm32*-*-*)
@@ -236,18 +236,18 @@ RM core in each cluster is normally dedicated to firmware: management of L2 cach
 So boot is done on RM to initialize cluster memory mapped registers for L2 cache, APIC, GIC and MAILBOX.
 
 **RM boot sequence**:
-- start.S: `_start`: core 64 bits mode, setting of the stack pointer and call of `__k1_rm_c_startup`
-- boot_c.c: `__k1_rm_c_startup`: 
+- start.S: `_start`: core 64 bits mode, setting of the stack pointer and call of `__kvx_rm_c_startup`
+- boot_c.c: `__kvx_rm_c_startup`: 
 ```c
-void __k1_rm_c_startup(void)
+void __kvx_rm_c_startup(void)
 {
-  __k1_low_level_startup();
-  __k1_rm_init();
-  __k1_do_rm_startup();
-  __k1_stop();
+  __kvx_low_level_startup();
+  __kvx_rm_init();
+  __kvx_do_rm_startup();
+  __kvx_stop();
 }
 ```
-- boot_c.c: `__k1_low_level_startup`
+- boot_c.c: `__kvx_low_level_startup`
   - init of exception vector (SFR:EV)
   - enable icache, dcache, streaming load, hardware loop
   - init of interupts, DAME (Data Asynchronous Memory Error)
@@ -255,97 +255,97 @@ void __k1_rm_c_startup(void)
   - enable L1 cache coherency
   - init of power controller
 
-- boot_c.c: `__k1_rm_init`
+- boot_c.c: `__kvx_rm_init`
   - TLS and BSS sections init
 
-- boot_c.c: `__k1_do_rm_startup`
-  - call of `__k1_start_pe(PE0, __k1_pe_libc_start, __k1_libc_args, K1_PE_STACK_START)`
+- boot_c.c: `__kvx_do_rm_startup`
+  - call of `__kvx_start_pe(PE0, __kvx_pe_libc_start, __kvx_libc_args, KVX_PE_STACK_START)`
 
-- boot_c.c: `__k1_start_pe`
-  - init of `_K1_PE_START_ADDRESS`: address of startup routine to call at boot time
-  - init of `_K1_PE_ARGS_ADDRESS`: address of `k1_boot_args_t` structure to pass `argc`, `argv` and `envp`
-  - init of `_K1_PE_STACK_ADDRESS`: PE0 stack start address
+- boot_c.c: `__kvx_start_pe`
+  - init of `_KVX_PE_START_ADDRESS`: address of startup routine to call at boot time
+  - init of `_KVX_PE_ARGS_ADDRESS`: address of `kvx_boot_args_t` structure to pass `argc`, `argv` and `envp`
+  - init of `_KVX_PE_STACK_ADDRESS`: PE0 stack start address
   - wakeup PE0 using power controller
 
-- boot_c.c: `__k1_stop`
+- boot_c.c: `__kvx_stop`
   - set RM in IDLE mode
 
 **PE0 boot sequence**:
 
-- start.S: `_start`: core 64 bits mode, setting of the stack pointer and call of `__k1_pe_libc_start` previously given during RM boot.
+- start.S: `_start`: core 64 bits mode, setting of the stack pointer and call of `__kvx_pe_libc_start` previously given during RM boot.
 
-- boot_c.c: `__k1_pe_c_startup`: 
+- boot_c.c: `__kvx_pe_c_startup`: 
 ```c
-void __k1_pe_c_startup(void)
+void __kvx_pe_c_startup(void)
 {
-  __k1_low_level_startup();
-  __k1_do_pe_startup();
-  __k1_stop();
+  __kvx_low_level_startup();
+  __kvx_do_pe_startup();
+  __kvx_stop();
 }
 ```
-- boot_c.c: `__k1_low_level_startup`
+- boot_c.c: `__kvx_low_level_startup`
   - init of exception vector (SFR:EV)
   - enable icache, dcache, streaming load, hardware loop
   - init of interupts, DAME (Data Asynchronous Memory Error)
   - enable L1 cache coherency
   - init of power controller
 
-- boot_c.c: `__k1_do_pe_startup`
-  - `__k1_pe_init`: init of sections TLS and BSS
-  - `__k1_finish_newlib_init`: some libc internal init for reentrance
-  - register `__k1_newlib_flushall` at exit to flush mainly IO streams at exit.
+- boot_c.c: `__kvx_do_pe_startup`
+  - `__kvx_pe_init`: init of sections TLS and BSS
+  - `__kvx_finish_newlib_init`: some libc internal init for reentrance
+  - register `__kvx_newlib_flushall` at exit to flush mainly IO streams at exit.
   - call main routine
   - call exit
   - while(1)
 
-- boot_c.c: `__k1_do_rm_startup`
-  - call of `__k1_start_pe(PE0, __k1_pe_libc_start, __k1_libc_args, K1_PE_STACK_START)`
+- boot_c.c: `__kvx_do_rm_startup`
+  - call of `__kvx_start_pe(PE0, __kvx_pe_libc_start, __kvx_libc_args, KVX_PE_STACK_START)`
 
-- boot_c.c: `__k1_start_pe`
-  - init of `_K1_PE_START_ADDRESS`: address of startup routine to call at boot time
-  - init of `_K1_PE_ARGS_ADDRESS`: address of k1_boot_args_t structure to pass argc, argv and envp
-  - init of `_K1_PE_STACK_ADDRESS`: PE0 stack start address
+- boot_c.c: `__kvx_start_pe`
+  - init of `_KVX_PE_START_ADDRESS`: address of startup routine to call at boot time
+  - init of `_KVX_PE_ARGS_ADDRESS`: address of kvx_boot_args_t structure to pass argc, argv and envp
+  - init of `_KVX_PE_STACK_ADDRESS`: PE0 stack start address
   - wakeup PE0 using power controller
 
-- boot_c.c: `__k1_stop`
+- boot_c.c: `__kvx_stop`
   - set RM in IDLE mode
 
 ## Exceptions handling
 
-K1 core has an Exception Vector register to initialize with a vector of 4 trampolines of maximum size 0x40 bytes:
+KVX cores have an Exception Vector register to initialize with a vector of 4 trampolines of maximum size 0x40 bytes:
 - DEBUG
 - TRAP
 - INTERRUPT
 - SYSCALL
 
-At boot time, `SFR[EV]` is initialized to `K1_EXCEPTION_ADDRESS` initialized by default in bare.ld linker script:
+At boot time, `SFR[EV]` is initialized to `KVX_EXCEPTION_ADDRESS` initialized by default in bare.ld linker script:
 
 ```c
-K1_EXCEPTION_ADDRESS = DEFINED(K1_EXCEPTION_ADDRESS) ? K1_EXCEPTION_ADDRESS : 0x400;
-K1_DEBUG_ADDRESS     = K1_EXCEPTION_ADDRESS + 0x00;
-K1_TRAP_ADDRESS      = K1_EXCEPTION_ADDRESS + 0x40;
-K1_INTERRUPT_ADDRESS = K1_EXCEPTION_ADDRESS + 0x80;
-K1_SYSCALL_ADDRESS   = K1_EXCEPTION_ADDRESS + 0xc0;
+KVX_EXCEPTION_ADDRESS = DEFINED(KVX_EXCEPTION_ADDRESS) ? KVX_EXCEPTION_ADDRESS : 0x400;
+KVX_DEBUG_ADDRESS     = KVX_EXCEPTION_ADDRESS + 0x00;
+KVX_TRAP_ADDRESS      = KVX_EXCEPTION_ADDRESS + 0x40;
+KVX_INTERRUPT_ADDRESS = KVX_EXCEPTION_ADDRESS + 0x80;
+KVX_SYSCALL_ADDRESS   = KVX_EXCEPTION_ADDRESS + 0xc0;
 ```
 Each address is used to init specific sections address in bare.ld linker script:
 
 ```c
-  .exception.debug K1_DEBUG_ADDRESS : {
+  .exception.debug KVX_DEBUG_ADDRESS : {
     /* The debug exception handler */
     KEEP(*(.exception.debug))
   } > internal_mem
 
-  .exception.trap K1_TRAP_ADDRESS : {
+  .exception.trap KVX_TRAP_ADDRESS : {
     /* The debug exception handler */
     KEEP(*(.exception.trap))
   } > internal_mem
 
-  .exception.interrupt K1_INTERRUPT_ADDRESS : {
+  .exception.interrupt KVX_INTERRUPT_ADDRESS : {
     /* The debug exception handler */
     KEEP(*(.exception.interrupt))
   } > internal_mem
 
-  .exception.syscall K1_SYSCALL_ADDRESS : {
+  .exception.syscall KVX_SYSCALL_ADDRESS : {
     /* The debug exception handler */
     KEEP(*(.exception.syscall))
   } > internal_mem
@@ -356,59 +356,59 @@ All exception trampolines are defined in start.S:
 
 ```
 	.section .exception.debug, "ax", @progbits
-	.globl k1c_debug_handler_trampoline
-	.proc k1c_debug_handler_trampoline
-k1c_debug_handler_trampoline:
-	goto __k1_asm_exceptions_handler
+	.globl kv3_debug_handler_trampoline
+	.proc kv3_debug_handler_trampoline
+kv3_debug_handler_trampoline:
+	goto __kvx_asm_exceptions_handler
 	;;
-	.endp k1c_debug_handler_trampoline
+	.endp kv3_debug_handler_trampoline
 
 	.section .exception.trap, "ax", @progbits
-	.globl k1c_trap_handler_trampoline
-	.proc k1c_trap_handler_trampoline
-k1c_trap_handler_trampoline:
-	goto __k1_asm_exceptions_handler
+	.globl kv3_trap_handler_trampoline
+	.proc kv3_trap_handler_trampoline
+kv3_trap_handler_trampoline:
+	goto __kvx_asm_exceptions_handler
 	;;
-	.endp k1c_trap_handler_trampoline
+	.endp kv3_trap_handler_trampoline
 
 	.section .exception.interrupt, "ax", @progbits
-	.globl k1c_interrupt_handler_trampoline 
-	.proc k1c_interrupt_handler_trampoline
-k1c_interrupt_handler_trampoline:
-	goto __k1_asm_exceptions_handler
+	.globl kv3_interrupt_handler_trampoline 
+	.proc kv3_interrupt_handler_trampoline
+kv3_interrupt_handler_trampoline:
+	goto __kvx_asm_exceptions_handler
 	;;
-	.endp k1c_interrupt_handler_trampoline
+	.endp kv3_interrupt_handler_trampoline
 
 	.section .exception.syscall, "ax", @progbits ;\
-	.globl k1c_syscall_handler_trampoline ;\
-	.proc k1c_syscall_handler_trampoline
-k1c_syscall_handler_trampoline:
-	goto __k1_asm_exceptions_handler
+	.globl kv3_syscall_handler_trampoline ;\
+	.proc kv3_syscall_handler_trampoline
+kv3_syscall_handler_trampoline:
+	goto __kvx_asm_exceptions_handler
 	;;
-	.endp k1c_syscall_handler_trampoline
+	.endp kv3_syscall_handler_trampoline
 ```
 
-- exceptions.S: `__k1_asm_exceptions_handler`
+- exceptions.S: `__kvx_asm_exceptions_handler`
   - Save context
   - Call corresponding exception handler depending on SFR[EC] (Exception Cause)
-  - Each exception handler call corresponding `__k1_do_<exception type>`
+  - Each exception handler call corresponding `__kvx_do_<exception type>`
   - Restore context
 
-- handlers.c: `__k1_do_hwtrap`
+- handlers.c: `__kvx_do_hwtrap`
   - if write is defined, print error message and exit with 1 as error code
   - cluster power off
 
-- handlers.c: `__k1_do_interrupt`
-  - if `__k1_int_handlers[<it number>]` is registered, call it
+- handlers.c: `__kvx_do_interrupt`
+  - if `__kvx_int_handlers[<it number>]` is registered, call it
 
-- handlers.c: `__k1_do_interrupt_dame`
-  - Do the same thing than `__k1_do_hwtrap`
+- handlers.c: `__kvx_do_interrupt_dame`
+  - Do the same thing than `__kvx_do_hwtrap`
 
-- handlers.c: `__k1_do_debug`
-  - Do the same thing than `__k1_do_hwtrap`
+- handlers.c: `__kvx_do_debug`
+  - Do the same thing than `__kvx_do_hwtrap`
 
-- handlers.c: `__k1_do_scall`
-  - syscall numbers are defined in libgloss/k1-elf/include/k1c/scall_no.h
+- handlers.c: `__kvx_do_scall`
+  - syscall numbers are defined in libgloss/kvx-elf/include/kv3/scall_no.h
   - only syscalls write and exit are managed.
   - syscall write (17) uses magic syscall 4094
   - syscall exit (1) uses magic syscall 4095.
@@ -416,5 +416,5 @@ k1c_syscall_handler_trampoline:
 ## Lock handling
 
 OS must provides some lock interface that must be used by libc.
-For elf toolchain, locks are defined in ./newlib/libc/sys/k1/lock.c.
+For elf toolchain, locks are defined in ./newlib/libc/sys/kvx/lock.c.
 As example, ClusterOS provides its locks api used in ./newlib/libc/sys/cos/lock.c.

--- a/refs/4.0.0-cd10.refs
+++ b/refs/4.0.0-cd10.refs
@@ -1,6 +1,6 @@
 # Github sha1 for Code Drop 4.0.0-cd10
-# Source this file before executing build-k1-xgcc.sh to build code drop 4.0.0-cd10
+# Source this file before executing build-kvx-xgcc.sh to build code drop 4.0.0-cd10
 export SHA1_GCC=c71ca71d13c581676af5fed32d1320f84befbf3b
-export SHA1_GDB=329a393af55b79626c87e65dbe36863ff22b6e93
+export SHA1_BINUTILS=329a393af55b79626c87e65dbe36863ff22b6e93
 export SHA1_NEWLIB=2c12340008c6a9760d5a9fdfabdf6114cc0d5573
 export TARGET=k1-elf

--- a/refs/4.0.0-cd11.refs
+++ b/refs/4.0.0-cd11.refs
@@ -1,6 +1,6 @@
 # Github sha1 for Code Drop 4.0.0-cd11
-# Source this file before executing build-k1-xgcc.sh to build code drop 4.0.0-cd11
+# Source this file before executing build-kvx-xgcc.sh to build code drop 4.0.0-cd11
 export SHA1_GCC=2e74d3fe9dd538da128f4775e6047e0db7458927
-export SHA1_GDB=329a393af55b79626c87e65dbe36863ff22b6e93
+export SHA1_BINUTILS=329a393af55b79626c87e65dbe36863ff22b6e93
 export SHA1_NEWLIB=f6f75c0554cd088874d6c8931a48638875b7adad
 export TARGET=k1-elf

--- a/refs/4.0.0-cd13.refs
+++ b/refs/4.0.0-cd13.refs
@@ -1,6 +1,6 @@
 # Github sha1 for Code Drop 4.0.0-cd13
-# Source this file before executing build-k1-xgcc.sh to build code drop 4.0.0-cd13
+# Source this file before executing build-kvx-xgcc.sh to build code drop 4.0.0-cd13
 export SHA1_GCC=29d150fc918386c30d2b66db0096617803b42bdf
-export SHA1_GDB=329a393af55b79626c87e65dbe36863ff22b6e93
+export SHA1_BINUTILS=329a393af55b79626c87e65dbe36863ff22b6e93
 export SHA1_NEWLIB=1eaa4253e77f5d97d84b096df39f9fdf3a9a9ee7
 export TARGET=k1-elf

--- a/refs/4.0.0-cd14.refs
+++ b/refs/4.0.0-cd14.refs
@@ -1,6 +1,6 @@
 # Github sha1 for Code Drop 4.0.0-cd14
-# Source this file before executing build-k1-xgcc.sh to build code drop 4.0.0-cd14
+# Source this file before executing build-kvx-xgcc.sh to build code drop 4.0.0-cd14
 export SHA1_GCC=29d150fc918386c30d2b66db0096617803b42bdf
-export SHA1_GDB=329a393af55b79626c87e65dbe36863ff22b6e93
+export SHA1_BINUTILS=329a393af55b79626c87e65dbe36863ff22b6e93
 export SHA1_NEWLIB=1eaa4253e77f5d97d84b096df39f9fdf3a9a9ee7
 export TARGET=k1-elf

--- a/refs/4.0.0-cd4.refs
+++ b/refs/4.0.0-cd4.refs
@@ -1,6 +1,6 @@
 # Github sha1 for Code Drop 4.0.0-cd4
-# Source this file before executing build-k1-xgcc.sh to build code drop 4.0.0-cd4
+# Source this file before executing build-kvx-xgcc.sh to build code drop 4.0.0-cd4
 export SHA1_GCC=3130e1ac4928043ca6572804065955a900795c67
-export SHA1_GDB=fe938e201ac54619a188fa92959bf0c41eff10f5
+export SHA1_BINUTILS=fe938e201ac54619a188fa92959bf0c41eff10f5
 export SHA1_NEWLIB=28980fd977bc0b006469dd24839b67b83f579874
 export TARGET=k1-elf

--- a/refs/4.0.0-cd5.refs
+++ b/refs/4.0.0-cd5.refs
@@ -1,6 +1,6 @@
 # Github sha1 for Code Drop 4.0.0-cd5
-# Source this file before executing build-k1-xgcc.sh to build code drop 4.0.0-cd5
+# Source this file before executing build-kvx-xgcc.sh to build code drop 4.0.0-cd5
 export SHA1_GCC=825cbcd26d19ca9a75fc57a8d3a18250976bc255
-export SHA1_GDB=045d13b376991b9cd59192b677f6a03ba3a8813a
+export SHA1_BINUTILS=045d13b376991b9cd59192b677f6a03ba3a8813a
 export SHA1_NEWLIB=28980fd977bc0b006469dd24839b67b83f579874
 export TARGET=k1-elf

--- a/refs/4.0.0-cd6.refs
+++ b/refs/4.0.0-cd6.refs
@@ -1,6 +1,6 @@
 # Github sha1 for Code Drop 4.0.0-cd6
-# Source this file before executing build-k1-xgcc.sh to build code drop 4.0.0-cd6
+# Source this file before executing build-kvx-xgcc.sh to build code drop 4.0.0-cd6
 export SHA1_GCC=6b3d63f69bfef7e69a0c171340eb7e4c42e97325
-export SHA1_GDB=ca74c0271fbed3fd0307056db6831baf74bb7392
+export SHA1_BINUTILS=ca74c0271fbed3fd0307056db6831baf74bb7392
 export SHA1_NEWLIB=6a49427d1df86abc54713b157d71a6e99f21355f
 export TARGET=k1-elf

--- a/refs/4.0.0-cd7.refs
+++ b/refs/4.0.0-cd7.refs
@@ -1,6 +1,6 @@
 # Github sha1 for Code Drop 4.0.0-cd7
-# Source this file before executing build-k1-xgcc.sh to build code drop 4.0.0-cd7
+# Source this file before executing build-kvx-xgcc.sh to build code drop 4.0.0-cd7
 export SHA1_GCC=691981747524a03a80c23cee5d549f96d539e925
-export SHA1_GDB=98502490a2ad7a4e44b299319b67af3729a8e4de
+export SHA1_BINUTILS=98502490a2ad7a4e44b299319b67af3729a8e4de
 export SHA1_NEWLIB=47907d9d673e1bbaddd4df41bb3e043861be623d
 export TARGET=k1-elf

--- a/refs/4.0.0-cd8.refs
+++ b/refs/4.0.0-cd8.refs
@@ -1,6 +1,6 @@
 # Github sha1 for Code Drop 4.0.0-cd8
-# Source this file before executing build-k1-xgcc.sh to build code drop 4.0.0-cd8
+# Source this file before executing build-kvx-xgcc.sh to build code drop 4.0.0-cd8
 export SHA1_GCC=54a10b30813f7ca24a3f287f696baddbe18fcc4c
-export SHA1_GDB=0dd69706ee176f787cc658d7ee6664dfda768649
+export SHA1_BINUTILS=0dd69706ee176f787cc658d7ee6664dfda768649
 export SHA1_NEWLIB=4e95abe4b1f8a081c4a9958394ab102762b7f049
 export TARGET=k1-elf

--- a/refs/4.0.0-cd9.refs
+++ b/refs/4.0.0-cd9.refs
@@ -1,6 +1,6 @@
 # Github sha1 for Code Drop 4.0.0-cd9
-# Source this file before executing build-k1-xgcc.sh to build code drop 4.0.0-cd9
+# Source this file before executing build-kvx-xgcc.sh to build code drop 4.0.0-cd9
 export SHA1_GCC=0f4084e0cc93323771850cfa66a5b4580631bc2d
-export SHA1_GDB=0be6d67ed9499469430b49e6bf4fe68db5fbd8f9
+export SHA1_BINUTILS=0be6d67ed9499469430b49e6bf4fe68db5fbd8f9
 export SHA1_NEWLIB=2c12340008c6a9760d5a9fdfabdf6114cc0d5573
 export TARGET=k1-elf

--- a/refs/4.1.0-cd1.refs
+++ b/refs/4.1.0-cd1.refs
@@ -1,5 +1,5 @@
 # Github sha1 for Code Drop 4.1.0-cd1
-# Source this file before executing build-k1-xgcc.sh to build this code drop
+# Source this file before executing build-kvx-xgcc.sh to build this code drop
 export SHA1_GCC=f6f2785ba66afb5b80e17e5409060061781d7ee4
-export SHA1_GDB=3aacfa058a0fe41705f67f18a54b8da3733be4ad
+export SHA1_BINUTILS=3aacfa058a0fe41705f67f18a54b8da3733be4ad
 export SHA1_NEWLIB=bf737d4d0e0eb0df50ab6ecda7b48bde1dc1aea6

--- a/refs/4.1.0-cd2.refs
+++ b/refs/4.1.0-cd2.refs
@@ -1,5 +1,5 @@
 # Github sha1 for Code Drop 4.1.0-cd2
-# Source this file before executing build-k1-xgcc.sh to build this code drop
+# Source this file before executing build-kvx-xgcc.sh to build this code drop
 export SHA1_GCC=4a387cafe92313fb04f94076cfff1cd418506aa7
-export SHA1_GDB=f289922613729f94f13ccef82c8a81ccdb56fe58
+export SHA1_BINUTILS=f289922613729f94f13ccef82c8a81ccdb56fe58
 export SHA1_NEWLIB=bf737d4d0e0eb0df50ab6ecda7b48bde1dc1aea6

--- a/refs/4.1.0-rc3.refs
+++ b/refs/4.1.0-rc3.refs
@@ -1,5 +1,5 @@
 # Github sha1 for Code Drop 4.1.0-rc3
-# Source this file before executing build-k1-xgcc.sh to build this code drop
+# Source this file before executing build-kvx-xgcc.sh to build this code drop
 export SHA1_GCC=6698b7c1f95d409c17010ebb371365929a75aed1
-export SHA1_GDB=bdb149798c216b022e27bede46a046a08b81f534
+export SHA1_BINUTILS=bdb149798c216b022e27bede46a046a08b81f534
 export SHA1_NEWLIB=cadc197cdf7c435ccb146327df714667370132dd

--- a/refs/4.1.0-rc4.refs
+++ b/refs/4.1.0-rc4.refs
@@ -1,5 +1,5 @@
 # Github sha1 for Code Drop 4.1.0-rc4
-# Source this file before executing build-k1-xgcc.sh to build this code drop
+# Source this file before executing build-kvx-xgcc.sh to build this code drop
 export SHA1_GCC=6698b7c1f95d409c17010ebb371365929a75aed1
-export SHA1_GDB=bdb149798c216b022e27bede46a046a08b81f534
+export SHA1_BINUTILS=bdb149798c216b022e27bede46a046a08b81f534
 export SHA1_NEWLIB=cadc197cdf7c435ccb146327df714667370132dd

--- a/refs/4.1.0-rc5.refs
+++ b/refs/4.1.0-rc5.refs
@@ -1,5 +1,5 @@
 # Github sha1 for Code Drop 4.1.0-rc4
-# Source this file before executing build-k1-xgcc.sh to build this code drop
+# Source this file before executing build-kvx-xgcc.sh to build this code drop
 export SHA1_GCC=6698b7c1f95d409c17010ebb371365929a75aed1
-export SHA1_GDB=bdb149798c216b022e27bede46a046a08b81f534
+export SHA1_BINUTILS=bdb149798c216b022e27bede46a046a08b81f534
 export SHA1_NEWLIB=cadc197cdf7c435ccb146327df714667370132dd

--- a/refs/4.1.0-rc6.refs
+++ b/refs/4.1.0-rc6.refs
@@ -1,5 +1,5 @@
 # Github sha1 for Code Drop 4.1.0-rc6
-# Source this file before executing build-k1-xgcc.sh to build this code drop
+# Source this file before executing build-kvx-xgcc.sh to build this code drop
 export SHA1_GCC=6698b7c1f95d409c17010ebb371365929a75aed1
-export SHA1_GDB=bdb149798c216b022e27bede46a046a08b81f534
+export SHA1_BINUTILS=bdb149798c216b022e27bede46a046a08b81f534
 export SHA1_NEWLIB=cadc197cdf7c435ccb146327df714667370132dd

--- a/refs/4.2.0-cd1.refs
+++ b/refs/4.2.0-cd1.refs
@@ -1,5 +1,5 @@
 # Github sha1 for Code Drop 4.2.0-cd1
-# Source this file before executing build-k1-xgcc.sh to build this code drop
+# Source this file before executing build-kvx-xgcc.sh to build this code drop
 export SHA1_GCC=50bb1935d20f383c3d37c98b681f63de873688b2
-export SHA1_GDB=c5e8437af055869c8666a1c1e5a391d9af5be0c0
+export SHA1_BINUTILS=c5e8437af055869c8666a1c1e5a391d9af5be0c0
 export SHA1_NEWLIB=cadc197cdf7c435ccb146327df714667370132dd


### PR DESCRIPTION
k1/k1c family/core have been renamed to kvx/kv3: fix script and docs.
Use binutils instead of gdb where applicable.
Apply shellcheck on build script.