### PR TITLE
Remove duplicate target option for newlib build

### DIFF
--- a/build-kvx-xgcc.sh
+++ b/build-kvx-xgcc.sh
@@ -111,7 +111,6 @@ pushd build-newlib
     --enable-multilib \
     --enable-target-optspace \
     --enable-newlib-io-c99-formats \
-    --target="${TARGET}" \
     --enable-newlib-multithread
 
 make all "$PARALLEL_JOBS" > /dev/null


### PR DESCRIPTION
Some cleanup for newlib configuration command. --target was set twice.