### PR TITLE
Avoid conflicts in release names for gcc and llvm toolchains

### DIFF
--- a/.github/workflows/release-kvx-elf.yml
+++ b/.github/workflows/release-kvx-elf.yml
@@ -46,7 +46,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        release_name: Release ${{ github.ref }} (GCC)
         draft: false
         prerelease: ${{ steps.get_prerelease.outputs.PRERELEASE }}
     - name: Download toolchain from build

--- a/.github/workflows/release-kvx-llvm.yml
+++ b/.github/workflows/release-kvx-llvm.yml
@@ -46,7 +46,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        release_name: Release ${{ github.ref }} (LLVM)
         draft: false
         prerelease: ${{ steps.get_prerelease.outputs.PRERELEASE }}
     - name: Download toolchain from build


### PR DESCRIPTION
Fix CI error when different releases have the same name.
See https://github.com/kalray/build-scripts/runs/2782582775.