### PR TITLE
Use a different tag name for llvm based releases

### DIFF
--- a/.github/workflows/release-kvx-elf.yml
+++ b/.github/workflows/release-kvx-elf.yml
@@ -46,7 +46,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }} (GCC)
+        release_name: Release ${{ github.ref }}
         draft: false
         prerelease: ${{ steps.get_prerelease.outputs.PRERELEASE }}
     - name: Download toolchain from build

--- a/.github/workflows/release-kvx-llvm.yml
+++ b/.github/workflows/release-kvx-llvm.yml
@@ -3,7 +3,7 @@ name: Release LLVM
 on:
   push:
     tags:
-      - v*
+      - llvm-v*
 
 jobs:
   build:

--- a/.github/workflows/release-kvx-llvm.yml
+++ b/.github/workflows/release-kvx-llvm.yml
@@ -46,7 +46,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }} (LLVM)
+        release_name: Release ${{ github.ref }}
         draft: false
         prerelease: ${{ steps.get_prerelease.outputs.PRERELEASE }}
     - name: Download toolchain from build


### PR DESCRIPTION
 This should really avoid CI errors caused by:
`Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}`